### PR TITLE
Add Flutter WMS skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# WMS Mobile Flutter App
+
+This project contains a basic Flutter application skeleton for a WMS mobile app using `flutter_riverpod` and `go_router`.
+
+## Requirements
+- Flutter 3.x SDK
+- Dart 3.x
+
+## Getting Started
+1. Install Flutter and run `flutter doctor`.
+2. Get dependencies:
+   ```bash
+   flutter pub get
+   ```
+3. Run the application:
+   ```bash
+   flutter run
+   ```
+
+The app uses Material 3 and Riverpod for state management. All network logic and barcode scanning are TODOs.

--- a/lib/features/auth/presentation/equipment_screen.dart
+++ b/lib/features/auth/presentation/equipment_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen to choose the equipment used by the agent.
+class EquipmentScreen extends ConsumerWidget {
+  const EquipmentScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    String? selectedEquipment;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Équipement')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              DropdownButtonFormField<String>(
+                decoration:
+                    const InputDecoration(labelText: 'Chariot / Transpalette'),
+                items: const [
+                  DropdownMenuItem(value: 'chariot', child: Text('Chariot')),
+                  DropdownMenuItem(
+                      value: 'transpalette', child: Text('Transpalette')),
+                ],
+                onChanged: (value) => selectedEquipment = value,
+                validator: (value) => value == null ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(equipmentProvider).select(...)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Équipement sélectionné')),
+                    );
+                    context.go('/home');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen where the user logs in.
+class LoginScreen extends ConsumerWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final emailController = TextEditingController();
+    final passwordController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Connexion')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Placeholder for logo/illustration
+              const FlutterLogo(size: 120),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: passwordController,
+                decoration: const InputDecoration(labelText: 'Mot de passe'),
+                obscureText: true,
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () {},
+                  child: const Text('Mot de passe oublié ?'),
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(authProvider).login(...)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Connexion réussie')));
+                    context.go('/equipment');
+                  }
+                },
+                child: const Text('Se connecter'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Home screen with navigation tiles.
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final agentName = 'Nom de l\'agent';
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('WMS Mobile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(agentName, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 16),
+            Expanded(
+              child: GridView.count(
+                crossAxisCount: 2,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+                children: [
+                  _HomeTile(label: 'Réception', route: '/reception'),
+                  _HomeTile(label: 'Rangement', route: '/rangement'),
+                  _HomeTile(label: 'Réappro.', route: '/replenishment'),
+                  _HomeTile(label: 'Commande', route: '/orders'),
+                  _HomeTile(label: 'Chargement', route: '/orders/loading'),
+                  _HomeTile(label: 'Inventaire', route: '/inventory'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeTile extends StatelessWidget {
+  final String label;
+  final String route;
+  const _HomeTile({required this.label, required this.route});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => context.go(route),
+      child: Card(
+        child: Center(child: Text(label, textAlign: TextAlign.center)),
+      ),
+    );
+  }
+}

--- a/lib/features/inventory/inventory_screen.dart
+++ b/lib/features/inventory/inventory_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Screen for inventory with tabs.
+class InventoryScreen extends ConsumerWidget {
+  const InventoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Inventaire'),
+          bottom: const TabBar(tabs: [
+            Tab(text: 'Emplacement'),
+            Tab(text: 'Support'),
+            Tab(text: 'Produit'),
+          ]),
+        ),
+        body: const TabBarView(
+          children: [
+            _InventoryTab(),
+            _InventoryTab(),
+            _InventoryTab(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InventoryTab extends StatelessWidget {
+  const _InventoryTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final formKey = GlobalKey<FormState>();
+    final qtyController = TextEditingController();
+
+    final lines = <String>[]; // TODO: inventory lines
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Form(
+        key: formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(child: _LinesList(lines: lines)),
+            TextFormField(
+              controller: qtyController,
+              decoration: const InputDecoration(labelText: 'Qté'),
+              keyboardType: TextInputType.number,
+              validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                if (formKey.currentState!.validate()) {
+                  // TODO: validate qty
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Inventaire validé')));
+                }
+              },
+              child: const Text('Valider'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LinesList extends StatelessWidget {
+  final List<String> lines;
+  const _LinesList({required this.lines});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: lines.length,
+      itemBuilder: (context, index) => ListTile(title: Text(lines[index])),
+    );
+  }
+}

--- a/lib/features/orders/expedition_task_screen.dart
+++ b/lib/features/orders/expedition_task_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen for expedition task.
+class ExpeditionTaskScreen extends ConsumerWidget {
+  const ExpeditionTaskScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final articleController = TextEditingController();
+    final locationController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Expédition')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner support'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: articleController,
+                decoration: const InputDecoration(labelText: 'Article'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: locationController,
+                decoration: const InputDecoration(labelText: 'Emplacement'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(orderProvider).validateExpedition(...)
+                    context.go('/orders/loading');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/orders/loading_screen.dart
+++ b/lib/features/orders/loading_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen for loading process.
+class LoadingScreen extends ConsumerWidget {
+  const LoadingScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final articleController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chargement')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner article'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: articleController,
+                decoration: const InputDecoration(labelText: 'Article'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(orderProvider).validateLoading(...)
+                    context.go('/orders/summary');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/orders/loading_summary_screen.dart
+++ b/lib/features/orders/loading_summary_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen displaying loading summary.
+class LoadingSummaryScreen extends ConsumerWidget {
+  const LoadingSummaryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lines = <String>[]; // TODO: summary lines
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Résumé chargement')),
+      body: Column(
+        children: [
+          Expanded(
+            child: _LinesList(lines: lines),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: FilledButton(
+              onPressed: () {
+                // TODO: finalize loading
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Chargement validé')),
+                );
+                context.go('/home');
+              },
+              child: const Text('Terminer'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LinesList extends StatelessWidget {
+  final List<String> lines;
+  const _LinesList({required this.lines});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: lines.length,
+      itemBuilder: (context, index) => ListTile(title: Text(lines[index])),
+    );
+  }
+}

--- a/lib/features/orders/order_screen.dart
+++ b/lib/features/orders/order_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen to enter order number.
+class OrderScreen extends ConsumerWidget {
+  const OrderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final orderController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Commande')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: orderController,
+                decoration: const InputDecoration(labelText: 'N° Commande'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(orderProvider).loadLines(...)
+                    context.go('/orders/picking');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/orders/picking_task_screen.dart
+++ b/lib/features/orders/picking_task_screen.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen for picking tasks.
+class PickingTaskScreen extends ConsumerWidget {
+  const PickingTaskScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lines = <String>[]; // TODO: order lines
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Préparation')),
+      body: _LinesList(
+        lines: lines,
+        onTap: (_) => context.go('/orders/support-validation'),
+      ),
+    );
+  }
+}
+
+class _LinesList extends StatelessWidget {
+  final List<String> lines;
+  final ValueChanged<String> onTap;
+  const _LinesList({required this.lines, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: lines.length,
+      itemBuilder: (context, index) {
+        final line = lines[index];
+        return ListTile(
+          title: Text(line),
+          onTap: () => onTap(line),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/orders/support_pick_validation_screen.dart
+++ b/lib/features/orders/support_pick_validation_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen to validate picked support.
+class SupportPickValidationScreen extends ConsumerWidget {
+  const SupportPickValidationScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final articleController = TextEditingController();
+    final locationController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Validation support')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner support'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: articleController,
+                decoration: const InputDecoration(labelText: 'Article'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: locationController,
+                decoration: const InputDecoration(labelText: 'Emplacement'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(orderProvider).validateSupport(...)
+                    context.go('/orders/expedition');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/rangement/rangement_screen.dart
+++ b/lib/features/rangement/rangement_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen for rangement (put away) process.
+class RangementScreen extends ConsumerWidget {
+  const RangementScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final locationController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rangement')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner support'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: locationController,
+                decoration:
+                    const InputDecoration(labelText: 'Emplacement destination'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(rangementProvider).validate(...)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Rangement effectué')));
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/reception/reception_line_detail_screen.dart
+++ b/lib/features/reception/reception_line_detail_screen.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Details and validation for a reception line.
+class ReceptionLineDetailScreen extends ConsumerWidget {
+  const ReceptionLineDetailScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final lotController = TextEditingController();
+    final dlcController = TextEditingController();
+    final qtyController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Détail ligne')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner support'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: lotController,
+                decoration: const InputDecoration(labelText: 'Lot'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: dlcController,
+                decoration: const InputDecoration(labelText: 'DLC'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: qtyController,
+                decoration: const InputDecoration(labelText: 'Qté reçue'),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(receptionProvider).validateLine(...)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Ligne validée')));
+                  }
+                },
+                child: const Text('Valider et continuer'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: () {
+                  showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Clôturer Réception ?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => context.pop(false),
+                          child: const Text('Non'),
+                        ),
+                        TextButton(
+                          onPressed: () => context.pop(true),
+                          child: const Text('Oui'),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+                child: const Text('Fermer support'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/reception/reception_lines_screen.dart
+++ b/lib/features/reception/reception_lines_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../models/wms_models.dart';
+
+/// Screen showing reception lines.
+class ReceptionLinesScreen extends ConsumerWidget {
+  const ReceptionLinesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lines = <ReceptionLine>[]; // TODO: load from provider
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Lignes de réception')),
+      body: _LinesList(
+        lines: lines,
+        onTap: (line) => context.go('/reception/lineDetail'),
+      ),
+    );
+  }
+}
+
+class _LinesList extends StatelessWidget {
+  final List<ReceptionLine> lines;
+  final ValueChanged<ReceptionLine> onTap;
+
+  const _LinesList({required this.lines, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: lines.length,
+      itemBuilder: (context, index) {
+        final line = lines[index];
+        return ListTile(
+          title: Text(line.itemNo),
+          subtitle: Text(line.description),
+          trailing: Text('${line.expectedQty} ${line.unitOfMeasure}'),
+          onTap: () => onTap(line),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/reception/reception_screen.dart
+++ b/lib/features/reception/reception_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen to enter reception number.
+class ReceptionScreen extends ConsumerWidget {
+  const ReceptionScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final receptionController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Réception')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: receptionController,
+                decoration:
+                    const InputDecoration(labelText: 'N° Réception'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(receptionProvider).loadLines(...)
+                    context.go('/reception/lines');
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/replenishment/replenishment_screen.dart
+++ b/lib/features/replenishment/replenishment_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Screen for replenishment process.
+class ReplenishmentScreen extends ConsumerWidget {
+  const ReplenishmentScreen({super.key});
+
+  Future<String> scanBarcode() async => 'TODO';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    final sourceController = TextEditingController();
+    final destController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Réapprovisionnement')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: () async {
+                  await scanBarcode();
+                },
+                child: const Text('Scanner support'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: sourceController,
+                decoration:
+                    const InputDecoration(labelText: 'Emplacement source'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: destController,
+                decoration:
+                    const InputDecoration(labelText: 'Emplacement destination'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () {
+                  if (formKey.currentState!.validate()) {
+                    // TODO: ref.read(replenishmentProvider).validate(...)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Réappro effectué')));
+                  }
+                },
+                child: const Text('Valider'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: () => context.pop(),
+                child: const Text('Retour'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'router.dart';
+import 'theme.dart';
+
+/// Entry point of the WMS Mobile app.
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+/// Root widget setting up theme and router.
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'WMS Mobile',
+      theme: buildLightTheme(),
+      routerConfig: buildRouter(),
+    );
+  }
+}

--- a/lib/models/wms_models.dart
+++ b/lib/models/wms_models.dart
@@ -1,0 +1,26 @@
+/// Data models for the WMS application.
+class ReceptionLine {
+  final String itemNo;
+  final String description;
+  final double expectedQty;
+  final String unitOfMeasure;
+
+  const ReceptionLine({
+    required this.itemNo,
+    required this.description,
+    required this.expectedQty,
+    required this.unitOfMeasure,
+  });
+}
+
+class Support {
+  // TODO: define id, type, location, etc.
+}
+
+class OrderLine {
+  // TODO: define order line fields
+}
+
+class InventoryLine {
+  // TODO: define inventory line fields
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'features/auth/presentation/login_screen.dart';
+import 'features/auth/presentation/equipment_screen.dart';
+import 'features/home/home_screen.dart';
+import 'features/reception/reception_screen.dart';
+import 'features/reception/reception_lines_screen.dart';
+import 'features/reception/reception_line_detail_screen.dart';
+import 'features/rangement/rangement_screen.dart';
+import 'features/replenishment/replenishment_screen.dart';
+import 'features/orders/order_screen.dart';
+import 'features/orders/picking_task_screen.dart';
+import 'features/orders/support_pick_validation_screen.dart';
+import 'features/orders/expedition_task_screen.dart';
+import 'features/orders/loading_screen.dart';
+import 'features/orders/loading_summary_screen.dart';
+import 'features/inventory/inventory_screen.dart';
+
+/// Builds the router for the application.
+GoRouter buildRouter() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/equipment',
+        builder: (context, state) => const EquipmentScreen(),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (context, state) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: '/reception',
+        builder: (context, state) => const ReceptionScreen(),
+        routes: [
+          GoRoute(
+            path: 'lines',
+            builder: (context, state) => const ReceptionLinesScreen(),
+          ),
+          GoRoute(
+            path: 'lineDetail',
+            builder: (context, state) => const ReceptionLineDetailScreen(),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/rangement',
+        builder: (context, state) => const RangementScreen(),
+      ),
+      GoRoute(
+        path: '/replenishment',
+        builder: (context, state) => const ReplenishmentScreen(),
+      ),
+      GoRoute(
+        path: '/orders',
+        builder: (context, state) => const OrderScreen(),
+        routes: [
+          GoRoute(
+            path: 'picking',
+            builder: (context, state) => const PickingTaskScreen(),
+          ),
+          GoRoute(
+            path: 'support-validation',
+            builder: (context, state) => const SupportPickValidationScreen(),
+          ),
+          GoRoute(
+            path: 'expedition',
+            builder: (context, state) => const ExpeditionTaskScreen(),
+          ),
+          GoRoute(
+            path: 'loading',
+            builder: (context, state) => const LoadingScreen(),
+          ),
+          GoRoute(
+            path: 'summary',
+            builder: (context, state) => const LoadingSummaryScreen(),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/inventory',
+        builder: (context, state) => const InventoryScreen(),
+      ),
+    ],
+  );
+}

--- a/lib/shared/providers/app_providers.dart
+++ b/lib/shared/providers/app_providers.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Placeholder providers for the application logic.
+final authProvider = Provider((ref) => null); // TODO
+final equipmentProvider = Provider((ref) => null); // TODO
+final receptionProvider = Provider((ref) => null); // TODO
+final orderProvider = Provider((ref) => null); // TODO
+final inventoryProvider = Provider((ref) => null); // TODO

--- a/lib/shared/widgets/placeholder.dart
+++ b/lib/shared/widgets/placeholder.dart
@@ -1,0 +1,1 @@
+/// Placeholder widget file for shared widgets.

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Builds the light theme for the app with custom colors.
+ThemeData buildLightTheme() {
+  const primaryColor = Color(0xFF0066cc);
+  const secondaryColor = Color(0xFFFFCC00);
+  return ThemeData.light().copyWith(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: primaryColor,
+      primary: primaryColor,
+      secondary: secondaryColor,
+    ),
+    useMaterial3: true,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: wms_mobile
+publish_to: 'none'
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.0.0
+  go_router: ^10.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter-based project structure with Riverpod and GoRouter
- implement screens for auth, reception, orders, inventory and more
- define minimal models and providers
- include theme, router and main entry point
- add README instructions

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687686faed408324a90398aaddecf491